### PR TITLE
Fixes #22: RSS channel element doesn't need the pubDate.

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -8,8 +8,6 @@ layout: null
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
-    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for issue in site.issues limit:10 %}
       <item>


### PR DESCRIPTION
Turns out, the `pubDate`/`lastBuildDate` are both optional and many feeds don't have them. FTFY 😆 
