### PR TITLE
Adds basic contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to _I Like Hillary but..._
+
+When contributing to this repository, please first discuss the change you wish to make via the issue tracker on this repository before making a change.
+
+This project follows the [DevProgress code of conduct](https://github.com/DevProgress/code-of-conduct) which you can read [here](https://github.com/DevProgress/code-of-conduct/blob/master/code-of-conduct.md). We also require that our contributors agree to the [DevProgress Contributor Agreement](https://github.com/DevProgress/contributor-agreement) found [here](https://github.com/DevProgress/contributor-agreement/blob/master/DevProgressContributorAgreement.md).
+
+## Interested in contributing?
+
+Take a look [our list of open issues](https://github.com/DevProgress/i-like-hillary-but/issues) for some work items you can help with. You are encouraged to contribute code, UI design, and content via Pull Requests on GitHub.
+
+If you would like to contribute in an area without a corresponding issue, please make sure to raise that with the maintainers of this repository. You can do that by opening a new issue to discuss your potential contribution.
+
+## Pull Request Process
+
+For content editors without Git, GitHub, and Markdown experience see [this crash course for content editors](https://github.com/Eyas/crash-course) for detailed instruction on how to contribute without command line tools.
+
+1. Create a topic branch for each Pull Request
+2. When possible, reference related issues using their issue number in your commit messages or Pull Request description
+3. Allow one or two reviews to go over your Pull Request, responding to their feedback as necessary
+  - Push additional changes to your topic branch as you respond to different pieces of feedback
+4. Once other repository maintainers sign off your Pull Request in its current form, you are free to merge the Pull Request if you are able to do so. Otherwise, a repository maintainer will proceed and merge the request.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ You can skip this step if you already have Ruby and Bundler installed.
 
 ## Test
 1. Run `rake test`.
+
+## Contributing
+
+Content, UI design, and frontend code contributions are welcome. Please see [our list of open issues](https://github.com/DevProgress/i-like-hillary-but/issues). Please see our [Contribution Guide](CONTRIBUTING.md) for more detail. The guide also covers the [DevProgress code of conduct](https://github.com/DevProgress/code-of-conduct) and the [DevProgress Contributor Agreement](https://github.com/DevProgress/contributor-agreement).


### PR DESCRIPTION
- A CONTRIBUTING.md file is added to the top-level directory, with some portions based on Good-CONTRIBUTING.md-template.md by GitHub user PurpleBooth available at https://gist.github.com/PurpleBooth/b24679402957c63ec426.
- This is linked to from README.md as well.
- The page also links to a crash course for content editors that I created earlier. This is separate and available here: https://github.com/Eyas/crash-course -- since I figure adding a bunch of step by step instructions and screenshots is a bit much to put in this repo.

This should resolve #28
