### PR TITLE
Switch to dual Jekyll config: one for dev, one for prod.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 _site
+_dev_config.yml
 .sass-cache
 .jekyll-metadata
 .DS_Store

--- a/local-serve.sh
+++ b/local-serve.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+cat _config.yml | grep destination: -v > _dev_config.yml
 
-jekyll serve
+jekyll serve --config=_dev_config.yml


### PR DESCRIPTION
Soo... a tiny clever hack to neatly split dev builds and prod builds. After this patch lands, running `local-serve.sh` will actually generate and watch the site in the `/_site` directory (which is explicitly git-ignored), and running `build.sh` will continue to generate the site in `/docs`.

The key benefit is that now you can build/rebuild the source all you want, and you don't need to clean up the patch to remove changes in the `/docs` dir.
