### PR TITLE
Enable HTTPS as cannonical protocol

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ description: >
   the following list!
 
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://hillarymyths.org" # the base hostname & protocol for your site
+url: "https://hillarymyths.org" # the base hostname & protocol for your site
 
 exclude:
   - vendor


### PR DESCRIPTION
https://hillarymyths.org is now working, let's shift absolute links to use that protocol.

Rakefile does not need update because it now uses regex to match both `http` and `https`.
