### PR TITLE
Improve mobile support on hero page

### DIFF
--- a/_layouts/hero.html
+++ b/_layouts/hero.html
@@ -25,18 +25,26 @@
       if (alwaysAnimate || shouldAnimate) {
         header.classList.add('animated-ease-in');
         header.classList.add('hero');
-        onMotionDetected(toggleHeroAnimation);
+        addMotionDetected();
       }
 
-      function onMotionDetected(handler) {
-        document.body.onmousemove = handler;
-        document.body.onscroll = handler;
-        document.body.onkeydown = handler;
+      function addMotionDetected() {
+        document.body.addEventListener('mousemove', toggleHeroAnimation);
+        document.body.addEventListener('scroll', toggleHeroAnimation);
+        document.body.addEventListener('keydown', toggleHeroAnimation);
+        document.body.addEventListener('touchstart', toggleHeroAnimation);
+      }
+
+      function removeMotionDetected() {
+        document.body.removeEventListener('mousemove', toggleHeroAnimation);
+        document.body.removeEventListener('scroll', toggleHeroAnimation);
+        document.body.removeEventListener('keydown', toggleHeroAnimation);
+        document.body.removeEventListener('touchstart', toggleHeroAnimation);
       }
 
       function toggleHeroAnimation() {
         header.classList.remove('hero');
-        onMotionDetected(null);
+        removeMotionDetected();
       }
 
     }();


### PR DESCRIPTION
- Listen to 'touchstart' events and animate then as well.
- Since touchstart is not available as `ontouchstart` everywhere, register it as an event listener.
- Change "motion detected" handlers to use addEventListener and removeEventListener
- 'touchstart' isn't available on all desktop browsers, but is available on the vast majority of mobile browsers
- Pointer events not supported yet
