### PR TITLE
Link to live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# "I'd vote for Hillary, But..." | Hillary Clinton Myths
+
+A website to refute myths and misconceptions about Hillary Clinton. The live version is at https://hillarymyths.org.
+
 ## Set up
 You can skip this step if you already have Ruby and Bundler installed.
 


### PR DESCRIPTION
Partly for usability and partly for SEO, let's include a link to the [the live site](https://hillarymyths.org/) from our GitHub repository.
