### PR TITLE
Fixes site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ title_postfix: " | Hillary Myths"
 email: ilikehillary@example.com
 
 description: >
-  "I'd vote for Hillary, but..." is a site designed to refute myths and
+  &ldquo;I'd vote for Hillary, but...&rdquo; is a site designed to refute myths and
   misconceptions about Hillary Clinton. Please pick your concern from
   the following list!
 


### PR DESCRIPTION
These quotes need to be escaped as they are messing up the HTML in the `<meta>` tags.
