### PR TITLE
Make page markup more "semantic"

### DIFF
--- a/_issues/bad_experience.md
+++ b/_issues/bad_experience.md
@@ -4,8 +4,8 @@ title: "isn't her experience all bad?"
 categories: experience
 ---  
   
-**Q:** Isn't her experience all bad? 
-  
+## Q: Isn't her experience all bad?
+
 **A**: In the first Presidential debate, Donald Trump claimed that Hillary "has experience, but it's bad experience." This is not true. Specifically, he was referring to the [Iran Nuclear Deal](http://correctrecord.org/the-path-to-a-landmark-deal-how-hillary-led-on-iran-sanctions/) and our [intervention in Libya](http://www.npr.org/2011/09/12/140292920/natos-intervention-in-libya-a-new-model):
 
 * Far from a failure, the Iran Nuclear Deal was [one of the most strategic successes](https://www.washingtonpost.com/opinions/the-obama-bet-that-paid-off/2015/09/15/e46b80f6-5be6-11e5-8e9e-dce8a2a2a679_story.html?utm_term=.225e39af4806) of the Obama administration. And the [crippling sanctions](http://correctrecord.org/the-path-to-a-landmark-deal-how-hillary-led-on-iran-sanctions/) that Hillary personally fought for pushed Iran to the negotiating table.
@@ -13,7 +13,7 @@ categories: experience
 * Hillary's critics have convinced many people that the Libyan crisis began and ended with the tragic attack on our mission in Benghazi. However, the U.S. intervention in Libya helped avert [mass killings](http://uk.reuters.com/article/libya-protests-gaddafi-idUKLDE71L26D20110222) by the Libyan government. It also led to the ouster and death of Moammar Gadhafi, a brutal dictator, terrorist supporter, and enemy of the United States. What if the United States had not intervened in Libya? According to [Ivo Daalder, President of the Chicago Council on Global Affairs and the U.S. Ambassador to NATO during the 2011 Libyan revolution](http://www.huffingtonpost.com/2015/03/07/libya-intervention-daalder_n_6809756.html):
 > We would have seen a massive humanitarian nightmare inflicted on the people of Libya by their government. 
 
-**Q**: What were Hillary's other accomplishments as a public servant?
+## Q: What were Hillary's other accomplishments as a public servant?
 
 **A**: Hillary's record as a public servant includes her time as Secretary of State, U.S. Senator from New York, First Lady of the United States, and the First Lady of Arkansas. Here are just a [few of her accomplishments](https://www.hillaryclinton.com/feed/seven-hillary-clintons-biggest-accomplishments/):
 
@@ -29,6 +29,6 @@ categories: experience
 
 * When Hillary was First Lady, she fought for health care reform. When that effort did not succeed, Hillary kept fighting. **She worked with Republicans and Democrats** to help create the [Children's Health Insurance Program](http://www.factcheck.org/2008/03/giving-hillary-credit-for-schip/). Today, CHIP **provides health care to more than 8 million children**.
 
-**Q**: So she only got into public service because she was Bill Clinton's wife, right?
+## Q: So she only got into public service because she was Bill Clinton's wife, right?
 
 **A**: No. Hillary's call to public service began before she married Bill. When Hillary graduated law school, she could have joined a prestigious law firm. Instead, she chose to take a job with the [Children's Defense Fund](https://www.hillaryclinton.com/feed/what-hillary-clintons-first-job-out-of-law-school-can-tell-us-about-who-she-is-today/), where **she worked with teenagers incarcerated in adult prisons and families with disabled children**.

--- a/_issues/but-hillary-wants-my-guns.md
+++ b/_issues/but-hillary-wants-my-guns.md
@@ -4,14 +4,14 @@ title: "doesn't she want my guns?"
 categories: guns, gun control
 ---
 
-Q: Doesn't Hillary want to take away my right to own a gun?
+## Q: Doesn't Hillary want to take away my right to own a gun?
 
 
 A: Hillary respects law-abiding citizens’ 2nd Amendment right to own guns. She just wants to put in place [common-sense solutions](https://www.hillaryclinton.com/issues/gun-violence-prevention/) to make our communities safer. 
 
 Guns kill [around 33,000](http://fivethirtyeight.com/features/gun-deaths/) Americans a year. Hillary is committed to reducing the epidemic of gun violence. 
 
-Q: What do those solutions look like?
+## Q: What do those solutions look like?
 
 A: Here are the facts. As president, Hillary will:
 

--- a/_issues/but-she-isnt-trustworthy.md
+++ b/_issues/but-she-isnt-trustworthy.md
@@ -4,7 +4,7 @@ title: "Hillary Clinton’s not trustworthy. She lies all the time, right?"
 categories: deception
 ---
 
-**Q**: Doesn't she lie all of the time?
+## Q: Doesn't she lie all of the time?
 
 **A**: No. Hillary is actually **one of the most truthful candidates** to run in the past three Presidential elections! Here are the facts:
 
@@ -14,7 +14,7 @@ categories: deception
 
 * Even one of her [long-time critics](https://www.theguardian.com/commentisfree/2016/mar/28/hillary-clinton-honest-transparency-jill-abramson) admits that Hillary is **"fundamentally honest and trustworthy"**.
 
-**Q**: If she's not a liar, where does this perception come from?
+## Q: If she's not a liar, where does this perception come from?
 
 **A**: Aside from the almost three decades of [conspiracy theories](http://www.motherjones.com/politics/2014/06/hillary-clinton-conspiracy-theories) aimed at destroying her reputation, there may be a psychological component to this perception. [Studies](https://www.washingtonpost.com/news/the-fix/wp/2016/05/29/does-hillary-clinton-face-a-different-standard-for-honesty/) have shown that **women are expected to be more honest than men**. According to Julie Dolan, professor of political science at Macalester College, and the lead author of [Women in Politics: Paths to Power and Political Influence](https://www.amazon.com/Women-Politics-Paths-Political-Influence/dp/0205827152):
 

--- a/_issues/clinton_foundation_crooked.md
+++ b/_issues/clinton_foundation_crooked.md
@@ -4,13 +4,13 @@ title: "isn't the Clinton Foundation corrupt?"
 categories: trust
 ---  
   
-**Q**: Isn't the Clinton Foundation corrupt?
+## Q: Isn't the Clinton Foundation corrupt?
 
 **A**: No. The Clinton Foundation is a world-renowned charitable organization that has received top marks from independent charity watchdog groups. In [an interview with CNN](http://www.cnn.com/videos/politics/2016/08/24/charity-watch-clinton-foundation-lv.cnn), CharityWatch President Daniel Borochoff said:
 
 > If Hillary Clinton wasn't running for President, the Clinton Foundation would be seen as one of the great humanitarian charities of our generation.
 
-**Q**: What do these independent organizations say about the Clinton Foundation?
+## Q: What do these independent organizations say about the Clinton Foundation?
 
 **A**: Independent charity watchdog agencies have given the Clinton Foundation the **highest ratings for transparency and accountability**.
 
@@ -18,18 +18,18 @@ categories: trust
 * [Charity Navigator](https://www.charitynavigator.org/index.cfm?bay=search.summary&orgid=16680) gave them **the highest possible rating, 4 stars**, with an incredible overall score of 94.74 out of 100.
 * [GuideStar](http://www.guidestar.org/profile/31-1580204) bestowed **Platinum status on the Clinton Foundation, indicating the foundation's commitment to transparency**.
 
-**Q**: OK, but the Clintons must make money from the foundation, right?
+## Q: OK, but the Clintons must make money from the foundation, right?
 
 **A**: Neither Hillary, Bill, nor Chelsea Clinton [draw a salary from the Clinton Foundation](https://www.clintonfoundation.org/about/frequently-asked-questions) or are otherwise compensated for their work for the foundation. Additionally:
 
 * A remarkable [**88% of the funds** collected by the Clinton Foundation went to programs](https://www.charitywatch.org/ratings-and-metrics/bill-hillary-chelsea-clinton-foundation/478).
 * There is [**no evidence**](http://www.vox.com/policy-and-politics/2016/8/30/12690444/alma-powell-clinton-foundation) to support accusations that Clinton Foundation donors gained special access or favors from the State Department under Hillary. 
 
-**Q**: What is The Clinton Foundation anyway?
+## Q: What is The Clinton Foundation anyway?
  
 **A**: The Clinton Foundation was founded by President Bill Clinton in 2001, to support the work of the Clinton Presidential Center, which contains his Presidential Library and supports the Arkansas community. He expanded the foundation's role in 2002 to improve global access to HIV/AIDS treatment. The foundation has continued to grow and take on new challenges, including battling climate change, fighting childhood obesity, and [increasing opportunities for women and girls](https://www.clintonfoundation.org/our-work/by-topic/girls-and-women), to name just a few.
 
-**Q**: What are some of the Clinton Foundation's accomplishments?
+## Q: What are some of the Clinton Foundation's accomplishments?
 
 **A**: The Clinton Foundation [saves lives and has helped millions of people worldwide](https://www.hillaryclinton.com/feed/the-clinton-foundation-explained/): 
 

--- a/_issues/emails.md
+++ b/_issues/emails.md
@@ -6,15 +6,15 @@ categories: controversy
 
 Source: [What the FBI Files Reveal About Hillary Clinton’s Email Server](http://www.politico.com/magazine/story/2016/09/hillary-clinton-emails-2016-server-state-department-fbi-214307)
  
-**Q: Isn't Hillary is a criminal because she used a private email server?**
+## Q: Isn't Hillary is a criminal because she used a private email server?
   
 **A**: No, an intensive FBI investigation concluded that there was **no criminal wrongdoing.** On July 5th, FBI Director James Comey took the unprecedented step of publicly criticizing Hillary for her use of private emails. However, he went on to say that the FBI investigation showed that there was insufficient evidence of any criminal wrongdoing.  
 
-Q: Even if it wasn't a crime, wasn't it against Department of State regulations?
+## Q: Even if it wasn't a crime, wasn't it against Department of State regulations?
 
 A: There were **no regulations against using a private email server** while Hillary was Secretary of State. During their investigation, FBI agents found there was “no restriction on use of personal email accounts for official business.”
 
-Q: OK, if it wasn't a crime or against the rules, she was still negligent and exposed government secrets to the world, right?
+## Q: OK, if it wasn't a crime or against the rules, she was still negligent and exposed government secrets to the world, right?
 
 A: No. Consider these facts:
 
@@ -22,11 +22,11 @@ A: No. Consider these facts:
 * Hillary strongly preferred in-person conversations and printed documents to emails. **Most of her communications were done outside of email.** To put things in perspective, of the approximately 40,000 emails sent and received on the private servers, **only 0.0048 percent** of those emails were even in question.
 * Hillary **used [Sensitive Compartmented Information Facilities (SCIFs)](https://en.wikipedia.org/wiki/Sensitive_Compartmented_Information_Facility)** throughout her tenure as Secretary of State. A SCIF is a secure area or room where sensitive information is viewed or discussed, and where secure telephone conversations are conducted. She even had SCIFs in her homes in Washington DC and Chappaqua, NY.
 
-Q: If she had nothing to hide, why did she destroy her old phones?
+## Q: If she had nothing to hide, why did she destroy her old phones?
 
 A: If Hillary had a government-issued Blackberry, it would have met a similar fate at the end of her tenure. Old government phones are  [completely wiped clean and recycled, or they are destroyed](https://www.wired.com/2016/09/actually-clinton-destroyed-phones-better/). Jonathan Zdziarski, iOS forensics expert and security researcher, stated that if he were to destroy a Blackberry, he'd use "a blender and fire."
 
-Q: And why did she delete those 33,000 emails?
+## Q: And why did she delete those 33,000 emails?
 
 A: FBI Director Comey explained that very well in his [testimony to Congress](https://www.c-span.org/video/?412315-1/fbi-director-james-comey-testifies-hillary-clinton-email-probe&live):
 

--- a/_issues/establishment_failed.md
+++ b/_issues/establishment_failed.md
@@ -3,7 +3,7 @@ layout: post
 title: "hasn't the establishment failed us?"  
 categories: obama
 ---  
-**Q**: Hasn't the establishment failed us?
+## Q: Hasn't the establishment failed us?
   
 **A**: No. President Obama inherited a [financial](http://www.csmonitor.com/Commentary/Opinion/2009/0218/p09s02-coop.html) disaster. And despite an [obstructionist Republican Congress](https://www.washingtonpost.com/opinions/republican-obstructionism-is-nothing-new/2016/02/15/2d856c12-d42c-11e5-b195-2e29a4e13425_story.html?utm_term=.7faadad9f0e1), look at [where we are now](http://www.nytimes.com/2016/05/01/magazine/president-obama-weighs-his-economic-legacy.html?_r=0):
 
@@ -12,7 +12,7 @@ categories: obama
 * The Dow Jones Industrial Average was below 7,000 points in 2009, **today it is over 18,000**.
 * And contrary to what many people think, our **federal deficit has declined by roughly three-quarters**.
 
-**Q**: How has the current administration helped regular Americans?
+## Q: How has the current administration helped regular Americans?
 
 **A**: The Obama administration fought for legislation to create jobs, close the gender pay gap, help people with "underwater" mortgages keep their houses, and provide access to health coverage for millions of Americans.
 
@@ -24,6 +24,6 @@ categories: obama
 
 * And perhaps President Obama's crowning achievement, the Affordable Care Act (informally known as "Obamacare"), [**provides health insurance to 11.3 million people**](https://www.washingtonpost.com/news/to-your-health/wp/2016/01/07/more-than-11-3-million-americans-signed-up-for-obamacare-report-says/)!
 
-**Q**: Is there more to do? 
+## Q: Is there more to do? 
 
 **A**: Of course there is! Hillary will continue to move our country forward, and fight for even more programs to help Americans who are struggling. Check out the [detailed plans](http://www.hillaryclinton.com) on her website.

--- a/_issues/hawk.md
+++ b/_issues/hawk.md
@@ -4,7 +4,7 @@ title: "isn't she a war hawk?"
 categories: policy
 ---  
 
-**Q: Isn't Hillary a "war hawk"?**
+## Q: Isn't Hillary a "war hawk"?
   
 **A**: No. A "war hawk" is considered to be someone who favors military use over diplomacy. That is absolutely NOT Hillary Clinton. Here are the facts:
 

--- a/_issues/hillary_is_cold.md
+++ b/_issues/hillary_is_cold.md
@@ -4,8 +4,8 @@ title: "isn't she cold, robotic, and unlikable?"
 categories: personality
 ---  
   
-**Q: Why is Hillary so cold, robotic, and unlikable?**
-  
+## Q: Why is Hillary so cold, robotic, and unlikable?
+
 **A**: Well, first of all, the real Hillary Clinton is none of those things. Just ask [the people who know her](http://www.vox.com/a/hillary-clinton-interview/the-gap-listener-leadership-quality). The Hillary that some people think is real is the result of decades-long attacks by her critics, and Hillary's admitted discomfort with the process of campaigning.
 
 [John Podesta](http://www.vox.com/a/hillary-clinton-interview/the-gap-listener-leadership-quality), Chief of Staff to President Bill Clinton, Counselor to President Barack Obama, and Chairman of Hillary's 2016 Presidential Campaign:
@@ -20,14 +20,14 @@ categories: personality
 [Chelsea Clinton](http://www.realclearpolitics.com/video/2016/07/28/chelsea_clinton_introduces_hillary_at_dnc_she_never_forgets_who_she_is_fighting_for.html):
 >"I never once doubted that my parents cared about my thoughts and my ideas, and **I always knew how deeply they love me**. That feeling of being valued and loved — that is what my mom wants for every child. It is the calling of her life."
 
-**Q**: So where does the myth that Hillary is unlikable come from?
+## Q: So where does the myth that Hillary is unlikable come from?
 
 **A**: The myth has two main origins: [decades-long attacks](https://decorrespondent.nl/5072/clinton-derangement-syndrome-diagnosing-the-real-reason-that-so-many-americans-hate-hillary/1434615793424-45000115) by Hillary’s critics; and the [pressures placed](http://www.nytimes.com/2016/09/25/opinion/sunday/hillary-clintons-angry-face.html?_r=0) on female public figures.
 
 * For two and a half decades, Hillary has faced attacks on everything from her [hairstyles](http://www.slate.com/articles/double_x/doublex/2015/11/hillary_clinton_hair_attacks_from_the_headband_to_the_wig.html) and [clothing choices](https://www.bustle.com/articles/86973-5-times-hillary-clintons-style-was-criticized-instead-of-her-ideas) to the [sound of her voice](http://www.huffingtonpost.com/entry/complaining-hillary-clintons-voice_us_579add5de4b0693164c0b55c), her [laugh](http://mediamatters.org/blog/2015/10/14/media-return-to-deriding-hillary-clintons-laugh/206136), and her [smile](http://fortune.com/2016/09/27/hillary-clinton-smiling-debate/) (or [absence of one](http://www.nytimes.com/2016/09/09/us/politics/hillary-clinton-smiling.html)). Even her [cookie recipe](http://www.cnn.com/2012/03/16/opinion/swinth-hillary-clinton/index.html) created controversy. 
 * If Hillary is perceived as too serious, she is labeled ["angry and defensive.”](http://nytlive.nytimes.com/womenintheworld/2016/09/08/clinton-criticized-for-not-smiling-enough-during-commander-in-chief-forum/) If she expresses passion for the causes she has fought for her whole political life, she is ["too emotional."](https://thinkprogress.org/media-torn-over-whether-to-cast-clinton-as-weak-or-calculating-for-emotional-display-89faa9827964#.45qbd7hn2) 
 
-**Q**: But doesn't politics and campaigning come naturally to her?
+## Q: But doesn't politics and campaigning come naturally to her?
 
 **A**: On the contrary, Hillary has acknowledged that [campaigning](http://www.politico.com/blogs/2016-dem-primary-live-updates-and-results/2016/03/hillary-clinton-i-am-not-a-natural-politician-220544) does not come easy for her. Nevertheless, those who [endorse](http://www.chron.com/opinion/recommendations/article/For-Hillary-Clinton-8650345.php) Clinton [note](http://www.azcentral.com/story/opinion/editorial/2016/09/27/hillary-clinton-endorsement/91198668/) that her emotional restraint and poise under pressure would help make her an effective president
 

--- a/_issues/isnt-hillary-too-sick.md
+++ b/_issues/isnt-hillary-too-sick.md
@@ -4,14 +4,14 @@ title: "isn't she too sick to be president?"
 categories: health
 ---
 
-**Q: Isn't Hillary too sick to be President?**
+## Q: Isn't Hillary too sick to be President?
 
 A: No, Hillary is in excellent physical condition.
 
 In 2015, Hillary’s personal physician, Dr. Lisa Bardack, released a [statement](https://m.hrc.onl/secretary/10-documents/01-health-financial-records/2015-07-28_Statement_of_Health_-_LBardack.pdf) on her medical history. Bardack concluded:
 >“Mrs. Clinton is a healthy 67-year-old female whose current medical conditions include hypothyroidism and seasonal pollen allergies…. She participates in a healthy lifestyle and has had a full medical evaluation, which reveals no evidence of additional medical issues or cardiovascular disease…. She is in excellent physical condition and fit to serve as President of the United States.”
 
-Q: Then what happened at the 9/11 Memorial?
+## Q: Then what happened at the 9/11 Memorial?
 
 A: On September 11, 2016, Hillary, who [had pneumonia,](http://www.theatlantic.com/news/archive/2016/09/hillary-clinton-overheated/499514/) stumbled while leaving an event in New York City. Recovered, she [returned to the campaign trail](http://www.latimes.com/nation/la-na-pol-clinton-campaigning-20160915-snap-story.html) four days later. One of the most famous living journalists in United States history, Dan Rather, put [this into context](https://www.facebook.com/theDanRather/posts/10157417560045716):
 
@@ -19,7 +19,7 @@ A: On September 11, 2016, Hillary, who [had pneumonia,](http://www.theatlantic.c
 
 Dan Rather has well over 40 years of context for Presidential campaigns; he ought to know what should be considered normal.
 
-Q: Why did they say she was suffering from heat exhaustion rather than pneumonia?
+## Q: Why did they say she was suffering from heat exhaustion rather than pneumonia?
 
 A: Hillary's illness at the 9/11 event was a result of overheating and overexertion, which is not uncommon when battling an infection like pneumonia. Thus the initial statement given by the campaign was accurate. Like many Americans, Hillary chose to continue working, even when ill, and did not share the information regarding her illness widely across the campaign. [It was only after this incident that Secretary Clinton and her campaign chose to spread the news of her illness and have her doctor comment further on her condition.](http://www.nbcnews.com/politics/2016-election/hillary-clinton-falls-ill-9-11-memorial-n-y-n646376)
 

--- a/_issues/trade.md
+++ b/_issues/trade.md
@@ -4,13 +4,13 @@ title: "isn't she for free trade?"
 categories: policy
 ---  
 
-**Q: Doesn't Hillary support trade agreements that take jobs away from American workers?**
+## Q: Doesn't Hillary support trade agreements that take jobs away from American workers?
   
 **A**: Not at all. Trade deals are complex because they are supposed to benefit all of the nations involved. However, Hillary strongly believes that **all trade deals must benefit American workers**, first and foremost. As a result, she isn't wholly pro-trade or anti-trade. As [Gene Sperling, director of the National Economic Council in the Clinton and Obama administrations](http://www.politifact.com/truth-o-meter/statements/2016/apr/10/bernie-s/clinton-voted-virtually-every-trade-agreement-kill/) put it:
 
 > Some people are generally pro-trade or anti-trade. She’s case-by-case on trade.
 
-**Q**: What is Hillary's voting record on trade?
+## Q: What is Hillary's voting record on trade?
 
 **A**: As a U.S. Senator from New York, Hillary voted in favor of roughly half of the trade deals that came before her. However, she voted against the [Dominican Republic-Central America Free Trade Agreement (DR-CAFTA)](https://scout.sunlightfoundation.com/item/speech/CREC-2005-06-30-pt2-PgS7697.chunk96/sen-hillary-clinton-senate), saying in 2005:
 
@@ -18,13 +18,13 @@ categories: policy
 
 And like **Senator Bernie Sanders**, Hillary voted against the [Trade Act of 2002](http://www.politifact.com/truth-o-meter/statements/2016/apr/10/bernie-s/clinton-voted-virtually-every-trade-agreement-kill/). This legislation extended the Andean Trade Preference Act, but also gave the President fast track authority to negotiate trade deals. Fast track authority means that when the President negotiates a trade deal, Congress can only vote for or against it.
 
-**Q**: But she "flip-flopped" on TPP, right?
+## Q: But she "flip-flopped" on TPP, right?
 
 **A**: No. Hillary did originally support the Trans-Pacific Partnership (TPP). However, when the final deal was finished, [it did not benefit American workers the way she thought it should](http://www.ontheissues.org/2016/Hillary_Clinton_Free_Trade.htm). As a result, she felt obligated to oppose it. At the Democratic Primary Debate on October 13, 2015, she said:
 
 > I have always fought for the same values and principles, but, like most human beings--including those of us who run for office--I do absorb new information. I do look at what's happening in the world. Take the trade deal. I did say, when I was secretary of state, three years ago, that I hoped it would be the gold standard. It was just finally negotiated last week, and in looking at it, it didn't meet my standards. My standards for more new, good jobs for Americans, for raising wages for Americans. And **I want to make sure that I can look into the eyes of any middle-class American and say, "this will help raise your wages."** And I concluded I could not.
 
-**Q**: Well, she is a huge fan of NAFTA, though, correct?
+## Q: Well, she is a huge fan of NAFTA, though, correct?
 
 **A**: Hillary is **not a die-hard supporter of the North American Free Trade Agreement (NAFTA)**. Back in 2007, Hillary had [this to say](http://www.ontheissues.org/Archive/2007_AFL-CIO_Dems_Free_Trade.htm) at the AFL-CIO Democratic Primary Forum:
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,6 +8,7 @@ layout: default
   {% endif %}
 
   <article class="post-content">
+    <h1 class="semantic-annotation">{{ post.title }}</h1>
     {{ content }}
   </article>
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -318,9 +318,18 @@ header.post-header h1 {
     }
 }
 
-article.post-content p {
+article.post-content {
 	font-size: 1.15em;
     color: $content-text-color;
+
+    h1, h2 {
+        margin-top: 1em;
+        color: $brand-color-dark;
+    }
+    h2 {
+        font-size: inherit;
+    }
+    .semantic-annotation { display: none; }
 }
 
 #feedback {

--- a/index.html
+++ b/index.html
@@ -1,12 +1,14 @@
 ---
 layout: hero
 ---
-<ul class="post-list">
-  {% for post in site.issues %}
-    <li>
-      <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">
-        <span class="wrapper">&hellip;&nbsp;{{ post.title | escape }}</span>
-      </a>
-    </li>
-  {% endfor %}
-</ul>
+<nav>
+  <ul class="post-list">
+    {% for post in site.issues %}
+      <li>
+        <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">
+          <span class="wrapper">&hellip;&nbsp;{{ post.title | escape }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>


### PR DESCRIPTION
1. add `<nav>` in main page
2. use `h2` for questions
3. add a hidden `h1` inside of `article`

3 is weird and it is the one I'm not sure about. Let me know if I should remove. Idea is that `h1` annotates its parent section  with semantic info, but our `h1` is located in a `header` section as a sibling of our `article`. For various flexboxy reasons it will be a hassle to move it out. So, question is-- drop `h1` and don't label title of article? do this? something else?
