### PR TITLE
Invert prod check in service-worker.js

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,7 @@
 layout: null
 ---
 
-{% if site.destination != 'docs' %}
+{% if site.destination == 'docs' %}
 
 var cacheName = 'i-like-hillary';
 var fontCacheName = 'fonts-gistatic-com';


### PR DESCRIPTION
Whoops. I accidentally left off my quick hack to debug Service Worker locally. This check should be inverted: no SW in development (so that you can refresh and see the changes right away), and full SW in prod (the changes appear on second reload).
